### PR TITLE
Get Median Array, fixes #41

### DIFF
--- a/src/components/experiments/ExperimentGraph.jsx
+++ b/src/components/experiments/ExperimentGraph.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+import { getMedianArray } from "../../state/experiments/selectors";
+
+export class ExperimentGraph extends React.Component {
+  render() {
+    return (
+      <div>
+        <h4>
+          Temporarily displaying median array: [ {this.props.median.toString()}{" "}
+          ] (will be replaced with graph in next PR)
+        </h4>
+      </div>
+    );
+  }
+}
+
+ExperimentGraph.propTypes = {
+  median: PropTypes.instanceOf(Array)
+};
+
+const mapStateToProps = state => ({
+  median: getMedianArray(state)
+});
+
+export default connect(mapStateToProps)(ExperimentGraph);

--- a/src/constants.js
+++ b/src/constants.js
@@ -15,3 +15,5 @@ export const STATUSES = {
     [STATUS_LIVE]: 5,
     [STATUS_COMPLETE]: 6
 }
+
+export const SECONDS_IN_A_DAY = 86400; // 24 x 60 x 60

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,6 +5,7 @@ import ExperimentList from "./components/experiments/ExperimentList";
 import ConnectedDatePicker from "./components/dates/DatePicker";
 import ConnectedTypeSelector from "./components/type/TypeSelector";
 import ConnectedStatusSelector from "./components/status/StatusSelector";
+import ConnectedExperimentGraph from "./components/experiments/ExperimentGraph";
 import { createStore, applyMiddleware } from "redux";
 import { combineReducers } from "redux-immutable";
 import experiments from "./state/experiments/reducer";
@@ -40,13 +41,14 @@ const store = createStore(
 
 const App = () => (
   <React.Fragment>
-    <ConnectedStatusSelector />
-    <ExperimentList />
     <h4>Start Date: </h4>
     <ConnectedDatePicker onChangeAction={START_DATE_SELECTED} />
     <h4>End Date: </h4>
     <ConnectedDatePicker onChangeAction={END_DATE_SELECTED} />
+    <ConnectedStatusSelector />
     <ConnectedTypeSelector />
+    <ConnectedExperimentGraph />
+    <ExperimentList />
   </React.Fragment>
 );
 

--- a/src/state/experiments/actions.js
+++ b/src/state/experiments/actions.js
@@ -1,7 +1,7 @@
 import { EXPERIMENT_DATA_RECEIVED } from "../action-types";
 
 export const fetchExperiments = () => dispatch => {
-  fetch("https://experimenter.services.mozilla.com/api/v1/experiments/")
+  fetch("https://stage.experimenter.nonprod.dataops.mozgcp.net/api/v1/experiments/")
     .then(res => res.json())
     .then(data => {
       dispatch({

--- a/src/state/experiments/selectors.js
+++ b/src/state/experiments/selectors.js
@@ -67,7 +67,7 @@ export const getMedianArray = (state) => {
     [STATUS_COMPLETE]: []
   }
   
-  const statusDates = getStatusDates(state);
+  const statusDates = getExperimentStatusToDaysData(state);
   statusDates.forEach(statusObject => {
     Object.keys(statusObject).forEach(key => {
       statuses[key].push(statusObject[key])
@@ -91,11 +91,11 @@ export const getMedianArray = (state) => {
  * 
  * This is used as a helper function for getMedianArray.
  */
-const getStatusDates = (state) => {
+const getExperimentStatusToDaysData = (state) => {
   const experiments = getFilteredExperiments(state);
 
   return experiments.map(experiment => {
-    const statuses = initializeStatusArray(0);
+    const statusesToNumDays = initializeStatusArray(0);
 
     const changes = experiment.get("changes");
     let oldDate = null;
@@ -106,14 +106,15 @@ const getStatusDates = (state) => {
       const newStatus = changelog.get("new_status");
   
       if (oldDate && oldStatus) {
-        statuses[oldStatus] += getNumberDaysBetweenDates(oldDate, changedDate)
+        statusesToNumDays[oldStatus] += getNumberDaysBetweenDates(oldDate, changedDate)
       }
 
       oldDate = changedDate;
       oldStatus = newStatus;
     });
 
-    return statuses;
+    console.log(statusesToNumDays);
+    return statusesToNumDays;
   })
 }
 

--- a/src/tests/state/experiments/selectors.test.js
+++ b/src/tests/state/experiments/selectors.test.js
@@ -1,5 +1,5 @@
 import { fromJS } from "immutable";
-import { getExperimentsCount, getFilteredExperiments } from "../../../state/experiments/selectors";
+import { getExperimentsCount, getFilteredExperiments, getMedian, getNumberDaysBetweenDates } from "../../../state/experiments/selectors";
 import { STATUS_DRAFT, STATUS_LIVE } from "../../../constants";
 
 describe("getExperimentsCount test", () => {
@@ -189,4 +189,39 @@ describe("getFilteredExperiments tests", () => {
     });
     expect(getFilteredExperiments(mockedState)).toEqual(fromJS([experiment1, experiment2]));
   });
+});
+
+describe("Median Array helper functions", () => {
+  it("should call getMedian() on an array with odd number of elements that are unsorted", () => {
+    expect(getMedian([10, 2, 4, 1, 8])).toEqual(4);
+  });
+
+  it("should call getMedian() on an array with even number of elements that are unsorted", () => {
+    expect(getMedian([10, 8, 1, 7])).toEqual(7.5);
+  });
+
+  it("should call getMedian() on an empty array", () => {
+    expect(getMedian([])).toEqual(0);
+  });
+
+  it("should call getMedian() on an array with one element", () => {
+    expect(getMedian([1])).toEqual(1);
+  });
+
+  // getNumberDaysBetweenDates
+  it("should call getNumberDaysBetweenDates() ", () => {
+    const date1 = "2019-03-20T19:40:24.413929Z";
+    const date2 = "2019-03-25T19:40:24.413929Z"
+    
+    expect(getNumberDaysBetweenDates(date2, date1)).toEqual(5);
+  });
+
+  it("should call getNumberDaysBetweenDates() where 0 number of days are between them", () => {
+    const date1 = "2019-03-20T01:00:00.000000Z";
+    const date2 = "2019-03-20T13:00:00.000000Z";
+    
+    expect(getNumberDaysBetweenDates(date2, date1)).toEqual(0.50);
+  });
+
+
 });


### PR DESCRIPTION
<img width="554" alt="Screen Shot 2019-08-12 at 5 33 21 PM" src="https://user-images.githubusercontent.com/50588415/62900602-97861880-bd28-11e9-9a1f-e80c82f1ba61.png">

This is what `getExperimentStatusToDaysData` returns: 
<img width="706" alt="Screen Shot 2019-08-12 at 5 33 34 PM" src="https://user-images.githubusercontent.com/50588415/62900621-9fde5380-bd28-11e9-8db8-d476b70a0443.png">

Median array is calculated to be: [ 0, 13.5, 6, 0, 0, 0, 0 ] 

(It's a bit of a long PR, with lots of helper functions in the selectors file... so I apologize in advance to whoever is reviewing this)

Tests will be added in a separate PR!